### PR TITLE
[BUGFIX] Make release workflow idempotent for UI-created releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,21 @@ jobs:
         id: tag
         run: echo "tag=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
 
+      # Non-fatal: the tag is the source of truth for the action, but a
+      # mismatched package.json version is confusing. Warn (don't fail) since
+      # the release may already be published by the time this runs.
+      - name: Check package.json version matches tag
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          pkg_version="$(node -p "require('./package.json').version")"
+          expected="${TAG#v}"
+          if [ "$pkg_version" != "$expected" ]; then
+            echo "::warning::package.json version ($pkg_version) does not match tag ($TAG). Consider bumping it to $expected."
+          else
+            echo "package.json version matches tag ($TAG)."
+          fi
+
       # Idempotent: if the release already exists (e.g. created via the GitHub
       # Releases UI, which also creates the tag that triggered this run), skip
       # creation instead of failing with "tag_name already exists". A tag-only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,19 @@ jobs:
         id: tag
         run: echo "tag=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
 
+      # Idempotent: if the release already exists (e.g. created via the GitHub
+      # Releases UI, which also creates the tag that triggered this run), skip
+      # creation instead of failing with "tag_name already exists". A tag-only
+      # push or workflow_dispatch still gets a release created here.
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; skipping creation."
+            exit 0
+          fi
           prerelease=""
           case "$TAG" in
             *-*) prerelease="--prerelease" ;;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commit-message-checker",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "commit-message-checker",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commit-message-checker",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "GitHub Action that checks commit messages of pushes and pull request against a regex pattern",
   "keywords": [
     "github",


### PR DESCRIPTION
Creating a release via the GitHub UI also creates the tag, whose push triggers this workflow, which then failed with HTTP 422 "tag_name already exists" when trying to create the release again.

Skip creation when a release for the tag already exists; a tag-only push or workflow_dispatch still creates one. The build/test/dist-in-sync checks always run on the tagged commit.